### PR TITLE
Add PCRE2 support, Upgrade Ubuntu/Alpine, Change tac_plus URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,26 @@
 # Compile tac_plus
-FROM ubuntu:20.04 as build
+FROM ubuntu:22.04 as build
 
 LABEL Name=tac_plus
-LABEL Version=1.3.0
+LABEL Version=1.3.1
 
 ARG SRC_VERSION
 ARG SRC_HASH
 
-ADD https://github.com/lfkeitel/event-driven-servers/archive/refs/tags/$SRC_VERSION.tar.gz /tac_plus.tar.gz
+ADD http://www.pro-bono-publico.de/projects/src/tac_plus.tar.bz2 /tac_plus.tar.bz2
 
 RUN echo "${SRC_HASH}  /tac_plus.tar.gz" | sha256sum -c -
 
 RUN apt update && \
-    apt install -y gcc libc6-dev make bzip2 libdigest-md5-perl libnet-ldap-perl libio-socket-ssl-perl && \
-    tar -xzf /tac_plus.tar.gz && \
-    cd /event-driven-servers-$SRC_VERSION && \
-    ./configure --prefix=/tacacs && \
+    apt install -y apt-utils libpcre2-dev gcc libc6-dev make bzip2 libdigest-md5-perl libnet-ldap-perl libio-socket-ssl-perl && \
+    tar -xf /tac_plus.tar.bz2 && \
+    cd /PROJECTS && \
+    ./configure --with-pcre2 --prefix=/tacacs && \
     make && \
     make install
 
 # Move to a clean, small image
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Lee Keitel <lfkeitel@usi.edu>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,7 @@ FROM ubuntu:22.04 as build
 LABEL Name=tac_plus
 LABEL Version=1.3.1
 
-ARG SRC_VERSION
-ARG SRC_HASH
-
 ADD http://www.pro-bono-publico.de/projects/src/tac_plus.tar.bz2 /tac_plus.tar.bz2
-
-RUN echo "${SRC_HASH}  /tac_plus.tar.gz" | sha256sum -c -
 
 RUN apt update && \
     apt install -y apt-utils libpcre2-dev gcc libc6-dev make bzip2 libdigest-md5-perl libnet-ldap-perl libio-socket-ssl-perl && \

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,26 +1,21 @@
 # Compile tac_plus
-FROM alpine:3.14 as build
+FROM alpine:3.18.0 as build
 
 LABEL Name=tac_plus
-LABEL Version=1.3.0
+LABEL Version=1.3.1
 
-ARG SRC_VERSION
-ARG SRC_HASH
-
-ADD https://github.com/lfkeitel/event-driven-servers/archive/refs/tags/$SRC_VERSION.tar.gz /tac_plus.tar.gz
-
-RUN echo "${SRC_HASH}  /tac_plus.tar.gz" | sha256sum -c -
+ADD http://www.pro-bono-publico.de/projects/src/tac_plus.tar.bz2 /tac_plus.tar.bz2
 
 RUN apk update && \
-    apk add build-base bzip2 perl perl-digest-md5 perl-ldap perl-io-socket-ssl bash && \
-    tar -xzf /tac_plus.tar.gz && \
-    cd /event-driven-servers-$SRC_VERSION && \
-    ./configure --prefix=/tacacs && \
+    apk add build-base bzip2 pcre2 pcre2-dev perl perl-digest-md5 perl-ldap perl-io-socket-ssl bash && \
+    tar -xf /tac_plus.tar.bz2 && \
+    cd /PROJECTS && \
+    ./configure --with-pcre2 --prefix=/tacacs && \
     env SHELL=/bin/bash make && \
     env SHELL=/bin/bash make install
 
 # Move to a clean, small image
-FROM alpine:3.14
+FROM alpine:3.18.0
 
 LABEL maintainer="Lee Keitel <lfkeitel@usi.edu>"
 
@@ -29,7 +24,7 @@ COPY tac_plus.sample.cfg /etc/tac_plus/tac_plus.cfg
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN apk update && \
-    apk add perl-digest-md5 perl-ldap perl perl-io-socket-ssl && \
+    apk add pcre2 pcre2-dev perl-digest-md5 perl-ldap perl perl-io-socket-ssl && \
     rm -rf /var/cache/apk/*
 
 EXPOSE 49


### PR DESCRIPTION
The following changes have been made:
- Added PCRE2 support - To allow for Perl RegEx. Helpful for features like rewriting usernames.
- Updated Ubuntu version from 20.04 to latest LTS 22.04.
- Changed tac_plus source download from lfkeitel's GitHub repo to the official project's website (www.pro-bono-publico.de).
- Due to the above I removed checksums. The pro-bono-publico.de download appears to change frequently.

Note that I haven't touched the Alpine dockerfile for this. Only tested with Ubuntu. 